### PR TITLE
validate social media username entries

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -28,6 +28,9 @@ class Developer < ApplicationRecord
     max_file_size: 10.megabytes
   validates :preferred_max_hourly_rate, allow_nil: true, numericality: {greater_than_or_equal_to: :preferred_min_hourly_rate}, if: -> { preferred_min_hourly_rate.present? }
   validates :preferred_max_salary, allow_nil: true, numericality: {greater_than_or_equal_to: :preferred_min_salary}, if: -> { preferred_min_salary.present? }
+  validates :github, {not_url: true}
+  validates :twitter, {not_url: true}
+  validates :linkedin, {not_url: true}
 
   @skills_regex = /^[-\w\s]+(?:,[-\w\s]*)*$/i
 

--- a/app/validators/not_url_validator.rb
+++ b/app/validators/not_url_validator.rb
@@ -1,0 +1,7 @@
+class NotUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value.nil? || value.match(/(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#()?&\/=]*)/).nil?
+      record.errors.add(attribute, "profile link must be only the username and not the full website address")
+    end
+  end
+end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -181,4 +181,49 @@ class DeveloperTest < ActiveSupport::TestCase
       refute @developer.valid?
     end
   end
+
+  test "invalid with twitter full URL" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, twitter: "https://twitter.com/hirethepivot")
+
+    refute developer.valid?
+    assert_not_nil developer.errors[:twitter]
+  end
+
+  test "invalid with linkedin full URL" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, twitter: "https://www.linkedin.com")
+
+    refute developer.valid?
+    assert_not_nil developer.errors[:linkedin]
+  end
+
+  test "invalid with github full URL" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, twitter: "github.com")
+
+    refute developer.valid?
+    assert_not_nil developer.errors[:github]
+  end
+
+  test "is valid with github username" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, name: "Foo", hero: "Bar", bio: "FooBar", pivot_skills: "customer relations, writing", technical_skills: "Ruby, Rails", github: "rails")
+
+    assert developer.valid?
+  end
+
+  test "is valid with linkedin username" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, name: "Foo", hero: "Bar", bio: "FooBar", pivot_skills: "customer relations, writing", technical_skills: "Ruby, Rails", linkedin: "ruby")
+
+    assert developer.valid?
+  end
+
+  test "is valid with twitter username" do
+    user = users(:with_available_profile)
+    developer = Developer.new(user: user, name: "Foo", hero: "Bar", bio: "FooBar", pivot_skills: "customer relations, writing", technical_skills: "Ruby, Rails", twitter: "hirethepivot")
+
+    assert developer.valid?
+  end
 end


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->

Currently, if a user enters a website address for `github`, `twitter`, or `linkedin`, the site accepts it as valid, even though the input is only for the username on those sites.

This PR adds a new custom validator that confirms an entry is not a URL and uses that not validator for those aforementioned attributes.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
