### PR TITLE
remove second component

### DIFF
--- a/app/components/loading_component.html.erb
+++ b/app/components/loading_component.html.erb
@@ -1,3 +1,0 @@
-<div class="w-full flex justify-center py-1">
-  <%= inline_svg_tag "icons/loading.svg", class: "text-gray-500" %>
-</div>


### PR DESCRIPTION
There were two `LoadingComponent` html templates, causing an ActionView error when trying to load `/developers`

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] Your code contains tests relevant for code you modified
- [ ] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
